### PR TITLE
mini12864: added a clarification

### DIFF
--- a/build/electrical/mini12864_klipper_guide.md
+++ b/build/electrical/mini12864_klipper_guide.md
@@ -19,6 +19,7 @@ nav_exclude: true
 
 ## Klipper
 *Note: Most stock voron configuration files already have appropriate configurations for this display built in, which simply needing to be un-commented.  As they are specific to the individual builds, they should be used in preference to the more generic configuration shown below.*
+
 For SKR boards, add the following `[board_pins]` section to the configuration:
 
 ```

--- a/build/electrical/mini12864_klipper_guide.md
+++ b/build/electrical/mini12864_klipper_guide.md
@@ -18,7 +18,7 @@ nav_exclude: true
 3. Connect EXP1 and EXP2 cables to the display and to your MCU board, being sure to match port numbers (EXP1 <> EXP1).
 
 ## Klipper
-
+*Note: Most stock voron configuration files already have appropriate configurations for this display built in, which simply needing to be un-commented.  As they are specific to the individual builds, they should be used in preference to the more generic configuration shown below.*
 For SKR boards, add the following `[board_pins]` section to the configuration:
 
 ```


### PR DESCRIPTION
People have been faithfully following this guide, and putting this version of the mini12864 config into their printer.cfg, rather than using the stock ones.  Hopefully this note will make the situation a little clearer to folk