### PR TITLE
Correct GPIO pin for mini E3 v2

### DIFF
--- a/build/software/miniE3_v20_klipper.md
+++ b/build/software/miniE3_v20_klipper.md
@@ -27,7 +27,7 @@ In the menu structure there are a number of items to be selected.
 * Ensure that the micro-controller architecture is selected to be 'STM32' and the processor model is set to 'STM32F103' with a 28KiB bootloader.
 * Select "Enable extra low-level configuration options"
 * Enable "Use USB for communication (instead of serial)"
-* Configure "GPIO pins to set at micro-controller startup" to '!PC14'.
+* Configure "GPIO pins to set at micro-controller startup" to '!PA14'.
 
 ![](./images/miniE3_v20_klipper_menuconfig.png)
 


### PR DESCRIPTION
Text incorrectly states '!PC14' while screenshot shows correct '!PA14'