### PR TITLE
Fix Switchwire E3 V2.0 Wiring

### DIFF
--- a/build/electrical/sw_miniE3_v20_wiring.md
+++ b/build/electrical/sw_miniE3_v20_wiring.md
@@ -11,13 +11,15 @@ nav_exclude: true
 * Plug in stepper motors for X, Y, Z, and E in positions Xm, Ym, ZAm, and Em
 * Plug Hot End thermistor to thermistor TH0
 * Plug Hot End heater in to E0
-* Plug Hot End Fan in to FAN0
-* Plug Part Cooling Fan in to HB
+* Plug Hot End Fan in to FAN1
+* Plug Part Cooling Fan in to FAN0
 * Plug Bed Thermistor in to THB
-* Connect SSR pins to PT-DET connector
+* Connect Bed Heater to HB connector
 * Connect X end stop to X-STOP connector
 * Connect Y end stop to Y-STOP connector
-* Wire 24V and -V from DC power supply to VIN and GND
+* Plug Probe GND and Signal (with BAT85 diode) in to Z-STOP
+* Connect Probe +V to VIN in terminal next to HB
+* Wire 24V and -V from DC power supply to VIN and GND terminals in corner
 * Connect USB Cable to your SKR mini E3, but do not connect it yet to your Raspberry Pi
 
 ![](./images/v0-miniE3-v20-mcu.png)


### PR DESCRIPTION
Fix wiring guide to follow the example printer.cfg in SW repo.
Move fans to FAN0 and FAN1 connectors.
Remove SSR wiring, replace with Bed Heater going to HB.
Add Probe wiring instructions.