### PR TITLE
remove -l from ls /dev/serial/by-id

### DIFF
--- a/build/software/configuration.md
+++ b/build/software/configuration.md
@@ -90,7 +90,7 @@ Locate the section starting with **[mcu]**.  The V2 will have an additional sect
 
 * Begin with all controllers disconnected from the Raspberry Pi.
 * For printers with just one controller, connect that controller to the Raspberry Pi.  For printers with two controllers, connect the X/Y/E controller.
-* On the Raspberry Pi, run `ls -l /dev/serial/by-id/`.
+* On the Raspberry Pi, run `ls /dev/serial/by-id/`.
 * The listing should look similar to this:
 
 ![](./images/one_mcu.png)


### PR DESCRIPTION
the -l doesn't add any information users actually need, and confuses the less linux savvy users.