### PR TITLE
Remove Mini12864 Klipper Guide from Nav-menu

### DIFF
--- a/build/electrical/mini12864_klipper_guide.md
+++ b/build/electrical/mini12864_klipper_guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Mini12864 Klipper Guide
-nav_order: 1
+nav_exclude: true
 ---
 
 # Mini12864 Klipper Guide


### PR DESCRIPTION
The page titled "Mini12864 Klipper Guide" is currently showing in the top nav menu, at the very top just under "Voron Documentation."  This is confusing for new comers.

![image](https://user-images.githubusercontent.com/104980/131560926-322ed72e-1262-4b94-ac72-59351c6eb507.png)

Following the example of all other displays, they have the `nav_exclude: true` flag set.  Therefore, this PR shoots to bring it in line with all other display docs.

This doc is referenced in other material, such as on this page: https://docs.vorondesign.com/build/electrical/  So, it is nor orphaned by this PR.

The change was done on this mass edit: https://github.com/VoronDesign/Voron-Documentation/blame/main/build/electrical/mini12864_klipper_guide.md#L4

