### PR TITLE
fix missing link to Klipper install instructions for BTT Octopus.

### DIFF
--- a/build/software/index.md
+++ b/build/software/index.md
@@ -47,6 +47,7 @@ At this point Klipper will be installed on the Raspberry Pi.  The next step is t
 * [SKR mini e3 V2.0](./miniE3_v20_klipper.md)
 * [FLY FLYF407ZG](./flyf407zg_klipper.md)
 * [Fysetc Spider](./spider_klipper.md)
+* [BTT Octopus](./octopus_klipper.md)
 
 ---
 ### Next: [Software Configuration](./configuration.md)


### PR DESCRIPTION
This just adds the link that's missing from the software index page. The instructions already exist, but were orphaned.