### PR TITLE
Update octopus wiring instructions to accommodate Trident.

### DIFF
--- a/build/electrical/index.md
+++ b/build/electrical/index.md
@@ -153,7 +153,7 @@ Follow the links to the wiring configuration guides specific to your printer and
 * [V1 - SKR 1.4](./v1_skr14_wiring.md)
 
 ### Trident
-* Coming Soon
+* [Trident - BigTreeTech Octopus](./v2_octopus_wiring.md)
 
 ### Voron 2
 * [V2 - SKR 1.3](./v2_skr13_wiring.md)

--- a/build/electrical/v2_octopus_wiring.md
+++ b/build/electrical/v2_octopus_wiring.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: "Voron V2 - Octopus (Pro) Wiring"
+title: "Voron V2 / Trident - Octopus (Pro) Wiring"
 nav_exclude: true
 ---
 
-# Voron V2 - BigTreeTech Octopus Wiring
+# Voron V2 / Trident - BigTreeTech Octopus Wiring
 
 ## Initial Preparation 
 
@@ -25,7 +25,10 @@ Set jumpers as shown:
 * Connect 24V and GND (V+ and V-) from the PSU to PWR and MOTOR_POWER 
 * Connect the A Motor (gantry left) to MOTOR0
 * Connect the B Motor (gantry right) to MOTOR1
-* Connect the Z, Z1, Z2, and Z3 Motors to MOTOR2_1, MOTOR3, MOTOR4 and MOTOR5
+* Connect the Z motor to MOTOR2_1 
+* Connect the Z1 motor to MOTOR3
+* Connect the Z2 motor to MOTOR4
+* Connect the Z3 motor to MOTOR5 (v2 only)
 * Connect the extruder motor to MOTOR6
 * Connect the hot end heater to HE0
 * Connect the bed SSR (DC Control Side) to HE1


### PR DESCRIPTION
This just slightly modifies the octopus wiring diagram to allow for usage with the trident, which should save effort on upkeep.