### PR TITLE
Add stepper driver note for v2_octopus_wiring.md.

### DIFF
--- a/build/electrical/v2_octopus_wiring.md
+++ b/build/electrical/v2_octopus_wiring.md
@@ -45,6 +45,9 @@ Set jumpers as shown:
 * Connect the V+ and 0V wires on the probe to PROBE
 * if using a mini12864 display, connect to EXP1 & EXP2, only after completing the steps shown [below](#mini-12864-Display)
 
+### Stepper Driver Note
+Although MOTOR2_2 is skipped when connecting the motors, the TMC2209 stepper drivers must be connected side-by-side. Leave the end stepper driver slot open nearest the USB C if using only seven (7) stepper drivers. Check stepper driver placement against the Octopus Wiring figure below.
+
 ![](./images/v2_octopus_wiring.png)
  
 ## mini 12864 Display


### PR DESCRIPTION
Drivers must be side-to-side for builds using only 7 drivers.

I ran into this issue, and found several people on the discord that also ran into "unable to connect to driver UART" issues. There are also open issues on bigtreetech's github repos for the Octopus v1.0.

I figured a quick note in the docs will help the people who bought kits with only 7 drivers like me. Feel free to rephrase it however you want. I tried to keep with the Voron documentation style and styled it after the H3 notes like the "Microfit Pins" entry on the /build/electrical page.