### PR TITLE
RPi bootscreen - Update compatibility note

### DIFF
--- a/community/howto/index.md
+++ b/community/howto/index.md
@@ -22,7 +22,7 @@ Community-generated documentation for the many items that the official guide may
 | [Switchwire Screws Adjust](./doublet/switchwire_screws_adjust.md) | DoubleT |
 | [Print Tuning Guide](./ellis/print-tuning-guide.md) | Ellis |
 | [Multi-Colour Prints with a Single Nozzle](./mikhail/multi-colour-prints-with-a-single-nozzle.md) | mikhail |
-| [Custom Raspberry Pi Boot screens ](./samwiseg0/voron_rpi_bootscreen.md) | samwiseg0 |
+| [Custom Raspberry Pi Boot Screens ](./samwiseg0/voron_rpi_bootscreen.md) | samwiseg0 |
 | [Klicky Probe as Endstop with constant Z Offset ](./Takuya/Klicky_Probe_AutoZ_Alternative.md) | Takuya & Clee |
 | [Setting Up and Calibrating Sensorless XY Homing](./clee/sensorless_xy_homing.md) | clee |
 

--- a/community/howto/index.md
+++ b/community/howto/index.md
@@ -22,7 +22,7 @@ Community-generated documentation for the many items that the official guide may
 | [Switchwire Screws Adjust](./doublet/switchwire_screws_adjust.md) | DoubleT |
 | [Print Tuning Guide](./ellis/print-tuning-guide.md) | Ellis |
 | [Multi-Colour Prints with a Single Nozzle](./mikhail/multi-colour-prints-with-a-single-nozzle.md) | mikhail |
-| [Custom Raspberry Pi Boot screens ](./samwiseg0/voron_rpi_bootscreen.md) | samwiseg0 |
+| [Custom Raspberry Pi Bootscreens ](./samwiseg0/voron_rpi_bootscreen.md) | samwiseg0 |
 
 
 ### External Links

--- a/community/howto/index.md
+++ b/community/howto/index.md
@@ -22,7 +22,7 @@ Community-generated documentation for the many items that the official guide may
 | [Switchwire Screws Adjust](./doublet/switchwire_screws_adjust.md) | DoubleT |
 | [Print Tuning Guide](./ellis/print-tuning-guide.md) | Ellis |
 | [Multi-Colour Prints with a Single Nozzle](./mikhail/multi-colour-prints-with-a-single-nozzle.md) | mikhail |
-| [Custom Raspberry Pi Bootscreens ](./samwiseg0/voron_rpi_bootscreen.md) | samwiseg0 |
+| [Custom Raspberry Pi Bootscreens](./samwiseg0/voron_rpi_bootscreen.md) | samwiseg0 |
 
 
 ### External Links

--- a/community/howto/samwiseg0/voron_rpi_bootscreen.md
+++ b/community/howto/samwiseg0/voron_rpi_bootscreen.md
@@ -3,7 +3,8 @@
 
 Source PSD and images can be found in my [GitHub repo](https://github.com/samwiseg0/misc_3dprinting/tree/main/guides/voron_rpi_bootscreen)! Feel free to reach out to me on discord [Samwiseg0#4034](https://discord.com/users/210122378317922308). I will be happy to customize the serial number on any of the splash screens.
 
- ## How to remove the text and logo on raspbian buster
+## NOTE:
+**This guide will only work on Raspberry Pi OS LITE images. If you are using fluidpi or mainsailos those images will work. The following procedure has been verified on buster and bullseye.**
 
  Start by removing all the default screens and also the Raspberry images. Also, disable all the bootup lines.
 

--- a/community/howto/samwiseg0/voron_rpi_bootscreen.md
+++ b/community/howto/samwiseg0/voron_rpi_bootscreen.md
@@ -1,24 +1,24 @@
 # Voron Raspberry Pi Bootscreens
 ![](./Images/boot_tile.png)
 
-Source PSD and images can be found in my [GitHub repo](https://github.com/samwiseg0/misc_3dprinting/tree/main/guides/voron_rpi_bootscreen)! Feel free to reach out to me on discord [Samwiseg0#4034](https://discord.com/users/210122378317922308). I will be happy to customize the serial number on any of the splash screens.
+Source PSD and images can be found in my [GitHub repo](https://github.com/samwiseg0/misc_3dprinting/tree/main/guides/voron_rpi_bootscreen)! Feel free to [reach out to me on Discord (Samwiseg0#4034)](https://discord.com/users/210122378317922308). I will be happy to customize the serial number on any of the splash screens.
 
 ## NOTE:
 **This guide will only work on Raspberry Pi OS LITE images. If you are using fluiddpi or mainsailos those images will work. The following procedure has been verified on buster and bullseye.**
 
- Start by removing all the default screens and also the Raspberry images. Also, disable all the bootup lines.
+Start by removing all the default screens and also the Raspberry images. Also, disable all the bootup lines.
 
- Edit `/boot/config.txt` to remove the color test/rainbow screen.
+Edit `/boot/config.txt` to remove the color test/rainbow screen.
 
- ```cmd
- sudo nano /boot/config.txt
- ```
+```cmd
+sudo nano /boot/config.txt
+```
 
 Add:
 ```cmd
 disable_splash=1
 ```
-Press **ctrl+X, Y for save and Enter** to return to the command line.
+Press **Ctrl+X, Y** for save and **Enter** to return to the command line.
 
 Edit `/boot/cmdline.txt`
  ```cmd
@@ -34,7 +34,7 @@ logo.nologo consoleblank=0 loglevel=1 quiet vt.global_cursor_default=0
 * `consoleblank=0 loglevel=1 quiet` - Disable the commands and various bits of the kernel
 * `vt.global_cursor_default=0`- Removes the blinking cursor before the image loads.
 
-Press **ctrl+X, Y for save and Enter** to return to the command line.
+Press **Ctrl+X, Y** for save and **Enter** to return to the command line.
 
 Remove the login prompt by running
 ```cmd
@@ -50,8 +50,7 @@ Install `fbi`
 sudo apt install fbi
 ```
 
-It will take a few seconds to install. After this we have to
-create a file by
+It will take a few seconds to install. After this we have to create a file by
 
 ```cmd
 sudo nano /etc/systemd/system/splashscreen.service
@@ -59,7 +58,7 @@ sudo nano /etc/systemd/system/splashscreen.service
 
 Add the following:
 
-```cmd
+```ini
 [Unit]
 Description=Splash screen
 DefaultDependencies=no
@@ -67,7 +66,7 @@ After=local-fs.target
 
 [Service]
 #ExecStartPre is to workaround a race condition with bullseye. It can be removed in most cases. If an error apears on the screen that says it "cannot open /dev/fb0" then make sure ExecStartPre is used.
-ExecStartPre=/usr/bin/sleep 1
+ExecStartPre=/usr/bin/sleep 2
 ExecStart=/usr/bin/fbi -d /dev/fb0 --noverbose -a /home/pi/boot-image.png
 StandardInput=tty
 StandardOutput=tty
@@ -75,11 +74,11 @@ StandardOutput=tty
 [Install]
 WantedBy=sysinit.target
 ```
- * `-d/dev/fb0` - Tells `fbi` which image to display.
+ * `-d/dev/fb0` - Tells `fbi` which framebuffer to use for displaying
 
  * `--noverbose` - Suppresses `fbi` ‘status bar’ at the bottom.
 
- * `-a` - If the selected image is in the proper measurements then no editing is required if not then “-a” will act as editor.
+ * `-a` - If the selected image is in the proper measurements then no editing is required; if not, then “-a” will act as editor.
 
  * `StandardInput`/`StandardOutput`  - Allows `fbi` get access to tty.
 
@@ -87,9 +86,9 @@ WantedBy=sysinit.target
 
  * `fbi` will be loaded in the boot process when `WantedBy` is accessed, not before the file system (and hence image) are ready, through the `After` option.
 
-Place the image on the pi and name it `boot-image.png`. The image should live in the main home directory for the `pi` user. The full path for the image is `/home/pi/boot-image.png` **You may use another name but you must change it in the systemd file above.**
+Place the image on the Pi and name it `boot-image.png`. The image should live in the main home directory for the `pi` user. The full path for the image is `/home/pi/boot-image.png` **You may use another name but you must change it in the systemd file above.**
 
-You can find a basic guide on how to conect to the pi and transfer a file [here](https://howchoo.com/pi/how-to-transfer-files-to-the-raspberry-pi). Note that when you connect to your pi via any of these methods the default location is `/home/pi/`. You should be able to just drop the file into the default directory after connecting.
+You can find a basic guide on how to conect to the Pi and transfer a file [here](https://howchoo.com/pi/how-to-transfer-files-to-the-raspberry-pi). Note that when you connect to your Pi via any of these methods the default location is `/home/pi/`. You should be able to just drop the file into the default directory after connecting.
 
 Enable the service by running
 ```cmd

--- a/community/howto/samwiseg0/voron_rpi_bootscreen.md
+++ b/community/howto/samwiseg0/voron_rpi_bootscreen.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Voron RaspberryPi Bootscreens
+title: Voron Raspberry Pi Boot screens
 nav_exclude: true
 ---
 
-# Voron RaspberryPi Bootscreens
+# Voron Raspberry Pi Boot screens
 ![](./Images/boot_tile.png)
 
 Source PSD and images can be found in my [GitHub repo](https://github.com/samwiseg0/misc_3dprinting/tree/main/guides/voron_rpi_bootscreen)! Feel free to [reach out to me on Discord (Samwiseg0#4034)](https://discord.com/users/210122378317922308). I will be happy to customize the serial number on any of the splash screens.

--- a/community/howto/samwiseg0/voron_rpi_bootscreen.md
+++ b/community/howto/samwiseg0/voron_rpi_bootscreen.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Voron Raspberry Pi Boot screens
+title: Voron Raspberry Pi Boot Screens
 nav_exclude: true
 ---
 
-# Voron Raspberry Pi Boot screens
+# Voron Raspberry Pi Boot Screens
 ![](./Images/boot_tile.png)
 
 Source PSD and images can be found in my [GitHub repo](https://github.com/samwiseg0/misc_3dprinting/tree/main/guides/voron_rpi_bootscreen)! Feel free to [reach out to me on Discord (Samwiseg0#4034)](https://discord.com/users/210122378317922308). I will be happy to customize the serial number on any of the splash screens.

--- a/community/howto/samwiseg0/voron_rpi_bootscreen.md
+++ b/community/howto/samwiseg0/voron_rpi_bootscreen.md
@@ -1,10 +1,10 @@
-# Voron RaspberryPi Bootscreens
+# Voron Raspberry Pi Bootscreens
 ![](./Images/boot_tile.png)
 
 Source PSD and images can be found in my [GitHub repo](https://github.com/samwiseg0/misc_3dprinting/tree/main/guides/voron_rpi_bootscreen)! Feel free to reach out to me on discord [Samwiseg0#4034](https://discord.com/users/210122378317922308). I will be happy to customize the serial number on any of the splash screens.
 
 ## NOTE:
-**This guide will only work on Raspberry Pi OS LITE images. If you are using fluidpi or mainsailos those images will work. The following procedure has been verified on buster and bullseye.**
+**This guide will only work on Raspberry Pi OS LITE images. If you are using fluiddpi or mainsailos those images will work. The following procedure has been verified on buster and bullseye.**
 
  Start by removing all the default screens and also the Raspberry images. Also, disable all the bootup lines.
 

--- a/community/howto/samwiseg0/voron_rpi_bootscreen.md
+++ b/community/howto/samwiseg0/voron_rpi_bootscreen.md
@@ -4,7 +4,7 @@
 Source PSD and images can be found in my [GitHub repo](https://github.com/samwiseg0/misc_3dprinting/tree/main/guides/voron_rpi_bootscreen)! Feel free to [reach out to me on Discord (Samwiseg0#4034)](https://discord.com/users/210122378317922308). I will be happy to customize the serial number on any of the splash screens.
 
 ## NOTE:
-**This guide will only work on Raspberry Pi OS LITE images. If you are using fluiddpi or mainsailos those images will work. The following procedure has been verified on buster and bullseye.**
+**This guide will only work on Raspberry Pi OS LITE images. If you are using FluiddPi or MainsailOS those images will work. The following procedure has been verified on buster and bullseye.**
 
 Start by removing all the default screens and also the Raspberry images. Also, disable all the bootup lines.
 

--- a/community/howto/samwiseg0/voron_rpi_bootscreen.md
+++ b/community/howto/samwiseg0/voron_rpi_bootscreen.md
@@ -66,6 +66,8 @@ DefaultDependencies=no
 After=local-fs.target
 
 [Service]
+#ExecStartPre is to workaround a race condition with bullseye. It can be removed in most cases. If an error apears on the screen that says it "cannot open /dev/fb0" then make sure ExecStartPre is used.
+ExecStartPre=/usr/bin/sleep 1
 ExecStart=/usr/bin/fbi -d /dev/fb0 --noverbose -a /home/pi/boot-image.png
 StandardInput=tty
 StandardOutput=tty


### PR DESCRIPTION
I recently discovered this process only works on RPi **lite** images. Since mainsailos and fluidd pi are based off that image they will not have an issue. But users who use the default image from the RPi imager will have an issue since it includes a UX. 

This change updates the page to include this information. 

I also updated the titles to be consistent on both the page and index, added a small delay on execution of the systemd service to workaround a race condition with bullseye, and updated/corrected some of the other text. Thanks @clee!