### PR TITLE
Add headers to community docs

### DIFF
--- a/community/electronics/Deuce/Voron2_Monster8_v1.0_Config.md
+++ b/community/electronics/Deuce/Voron2_Monster8_v1.0_Config.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Voron V2 / Trident - MKS Makerbase Monster8 Wiring
+nav_exclude: true
+---
+
 # Voron V2 / Trident - MKS Makerbase Monster8 Wiring
 
 ## Initial Preparation 

--- a/community/howto/clee/sensorless_xy_homing.md
+++ b/community/howto/clee/sensorless_xy_homing.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Setting Up and Calibrating Sensorless XY Homing
+nav_exclude: true
+---
+
 # Setting Up and Calibrating Sensorless XY Homing
 
 When using the TMC2130 / TMC2209 / TMC2660 / TMC5160 drivers, the StallGuard feature makes it possible to set up sensorless homing on the X and Y axes for CoreXY machines. The Klipper project [has a page with documentation and recommendations on getting it working][KlipperTMCDrivers]. 

--- a/community/howto/index.md
+++ b/community/howto/index.md
@@ -23,6 +23,7 @@ Community-generated documentation for the many items that the official guide may
 | [Print Tuning Guide](./ellis/print-tuning-guide.md) | Ellis |
 | [Multi-Colour Prints with a Single Nozzle](./mikhail/multi-colour-prints-with-a-single-nozzle.md) | mikhail |
 | [Custom Raspberry Pi Boot screens ](./samwiseg0/voron_rpi_bootscreen.md) | samwiseg0 |
+| [Setting Up and Calibrating Sensorless XY Homing](./clee/sensorless_xy_homing.md) | clee |
 
 
 ### External Links

--- a/community/howto/samwiseg0/voron_rpi_bootscreen.md
+++ b/community/howto/samwiseg0/voron_rpi_bootscreen.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Voron RaspberryPi Bootscreens
+nav_exclude: true
+---
+
 # Voron RaspberryPi Bootscreens
 ![](./Images/boot_tile.png)
 


### PR DESCRIPTION
Should clean up the docs site's navigation menu.

Also, this adds a link for my sensorless guide to the howto index.