### PR TITLE
Update installing_heater_with_rtv.md

### DIFF
--- a/community/howto/fulg/installing_heater_with_rtv.md
+++ b/community/howto/fulg/installing_heater_with_rtv.md
@@ -8,7 +8,7 @@ nav_exclude: true
 
 In some cases the bed heater may need / want to be installed with something other than the normally provided 468MP adhesive sheet.  This can be a heter ordered without the adhesive, a heater being reinstalled, or a desire to have the heater glued on above the rated temperature of the 468MP adhesive.
 
-_Note:  This guide is not intended for installing a heater that already came with a 468MP adhesive sheet installed. In the installation manual Keenovo recommends sealing the edges of the pad with RTV, that is not the same as using RTV as the main adhesive. In their case it is a safety measure to ensure the pad cannot peel off with time. Slathering RTV all over the pad is not helpful._
+_Note:  This guide is not intended for installing a heater that already came with a 468MP adhesive sheet installed._
 
 In my experience 468MP starts to degrade when going over 115C, not that there is a risk of adhesive failure but that it starts to smell really bad, and that smell only gets worse with time. It is permanent. Not everyone is affected though so the exact cause is still unknown. 468MP has a shelf life, it is possible it is related to that (maybe I had old stock, maybe it depends on environmental factors...).
 

--- a/community/howto/fulg/installing_heater_with_rtv.md
+++ b/community/howto/fulg/installing_heater_with_rtv.md
@@ -8,7 +8,9 @@ nav_exclude: true
 
 In some cases the bed heater may need / want to be installed with something other than the normally provided 468MP adhesive sheet.  This can be a heter ordered without the adhesive, a heater being reinstalled, or a desire to have the heater glued on above the rated temperature of the 468MP adhesive.
 
-_Note:  This guide is not intended for installing a heater that already came with a 468MP adhesive sheet installed._
+
+## _Note:  This guide is NOT intended for installing a heater that already came with a 468MP adhesive sheet installed._
+
 
 In my experience 468MP starts to degrade when going over 115C, not that there is a risk of adhesive failure but that it starts to smell really bad, and that smell only gets worse with time. It is permanent. Not everyone is affected though so the exact cause is still unknown. 468MP has a shelf life, it is possible it is related to that (maybe I had old stock, maybe it depends on environmental factors...).
 


### PR DESCRIPTION
I contacted Keenovo about the use of RTV for 3d printers and they responded that instructions for the use of RTV is for sealing oil pans.   I feel that the use of RTV for the reinforcement of the heater pad that already have an adhesive should not be recommended since it's an unnecessary safety hazard.

"
Johnny Tang | KEENOVO <sales@keenovo.com>
Wed, Mar 9, 4:02 AM (1 day ago)
to me

Hi,

Thank you for the contact!

Actually, the best approach from our perspective is a clamp as explained in this post:

https://keenovo.store/blogs/how-to/how-to-achieve-a-perfect-installation-of-a-keenovo-heater-pad-to-your-3d-printers-build-plate
Basically, the RTV sealing is mostly suggested for engine oil pan heaters.

Thank you!
Please feel free to contact us if you have any questions.
Best Regards,

Johnny Tang | Sales Department

Mobile:+86 186 1635 0189"