### PR TITLE
fix wording in z endstop configuration guide.

### DIFF
--- a/community/howto/120decibell/z_endstop_configuration.md
+++ b/community/howto/120decibell/z_endstop_configuration.md
@@ -74,4 +74,4 @@ The initial Z offset can also be set using gcode or be adjusted using the front 
 
 **_Making the position\_endstop value larger / more positive will move the nozzle closer to the print surface._**
 
-**_Making the Z offset value larger / more positive will move the nozzle further from the print surface._**
+**_Making the position\_endstop value smaller / more negative will move the nozzle further from the print surface._**


### PR DESCRIPTION
needs to be signed off by @bdbell since it's his guide.