### PR TITLE
Remove "Dual MCU" reference

### DIFF
--- a/hardware.md
+++ b/hardware.md
@@ -32,7 +32,7 @@ The [Voron Trident](https://vorondesign.com/voron_trident) is a traditional Core
 
 ## Voron 2
 
-The [Voron V2](https://vorondesign.com/voron2.4) is a modified CoreXY design with a static bed and a gantry that moves along the Z axis. It is a much more complex build because it includes things such as 4-point gantry tramming to align to the print surface, dual MCUs, and other unique features. It is also designed to be fully enclosed so it prints ABS or similar filaments very well. Due to the linear rails the design is scalable in stock form from 250mm^3 and 300mm^3 all the way up to 350mm^3. More linear rails, larger print surface, and other V2-specific items make this printer more expensive, at between \$1,500 - \$1,900. Current release is V2.4r1.
+The [Voron V2](https://vorondesign.com/voron2.4) is a modified CoreXY design with a static bed and a gantry that moves along the Z axis. It is a much more complex build because it includes things such as 4-point gantry tramming to align to the print surface, and other unique features. It is also designed to be fully enclosed so it prints ABS or similar filaments very well. Due to the linear rails the design is scalable in stock form from 250mm^3 and 300mm^3 all the way up to 350mm^3. More linear rails, larger print surface, and other V2-specific items make this printer more expensive, at between \$1,500 - \$1,900. Current release is V2.4r1.
 
 [V2.4 Quad Level](https://www.youtube.com/watch?v=xfsnEO2VtwM)
 


### PR DESCRIPTION
Dual MCUs are no longer the way to go it seems, BOM just says "Controller with 7+ Stepper outputs" (probably need to also update "Sourcing guild" sheet which still says "SKR 1.4"x2) most commonly AFAIK this is built nowadays with the BigTreeTech Octopus control board, which is also what's provided in the most kits