### PR TITLE
Update Trident Bed Locating Initial Startup Docs

### DIFF
--- a/build/startup/index.md
+++ b/build/startup/index.md
@@ -152,7 +152,7 @@ Once the Z endstop is fixed into position the base plate should be adjusted so t
 
 Before the 0,0 point and Z endstop locations are set, the physical locations of the Z endstop and print bed need to be finalized.
 
-The Z endstop should be located at close to max X position.  Home X and Y with `G28 X Y`  and then traverse just Y to locate a Z endstop position at the maximum X travel that will still trigger the endstop.  Lock down the Z endstop at that position.
+The Z endstop should be located at close to max Y position.  Home X and Y with `G28 X Y`  and then traverse just X to locate a Z endstop position at the maximum Y travel that will still trigger the endstop.  Lock down the Z endstop at that position.
 
 Once the Z endstop is fixed into position the base plate should be adjusted so that the Z endstop pin is approximately 2-3mm from the aluminum base plate.
 


### PR DESCRIPTION
Bed Locating in Trident had the axis inverted. It instructed users that the Z endstop be located near max X rather than max Y. It also instructed the user to traverse the Y axis until they aligned over the Z endstop at maximum X travel. 

The Trident Z endstop is mounted at the centre rear of the bed. Therefore, we should be seeking max Y and adjusting X