### PR TITLE
Fix issue #300; flipping X/Y for Trident

### DIFF
--- a/build/startup/index.md
+++ b/build/startup/index.md
@@ -152,7 +152,13 @@ Once the Z endstop is fixed into position the base plate should be adjusted so t
 
 Before the 0,0 point and Z endstop locations are set, the physical locations of the Z endstop and print bed need to be finalized.
 
+### V1, Legacy:
+
 The Z endstop should be located at close to max X position.  Home X and Y with `G28 X Y`  and then traverse just Y to locate a Z endstop position at the maximum X travel that will still trigger the endstop.  Lock down the Z endstop at that position.
+
+### Trident:
+
+The Z endstop should be located at close to max Y position.  Home X and Y with `G28 X Y`  and then traverse just X to locate a Z endstop position at the maximum Y travel that will still trigger the endstop.  Lock down the Z endstop at that position.
 
 Once the Z endstop is fixed into position the base plate should be adjusted so that the Z endstop pin is approximately 2-3mm from the aluminum base plate.
 

--- a/build/startup/index.md
+++ b/build/startup/index.md
@@ -259,7 +259,7 @@ It will perform a PID calibration routine that will last about 5 minutes. Once i
 Depending on the printer type and capability, the following command(s) are used:
 
 * V0: `BED_SCREWS_ADJUST`
-* V1, Legacy: `Z_TILT_ADJUST`, `SCREWS_TILT_CALCULATE`
+* V1, Trident, Legacy: `Z_TILT_ADJUST`, `SCREWS_TILT_CALCULATE`
 * V2: `QUAD_GANTRY_LEVEL`
 
 ### Bed Screws (V0)

--- a/build/startup/index.md
+++ b/build/startup/index.md
@@ -259,7 +259,8 @@ It will perform a PID calibration routine that will last about 5 minutes. Once i
 Depending on the printer type and capability, the following command(s) are used:
 
 * V0: `BED_SCREWS_ADJUST`
-* V1, Trident, Legacy: `Z_TILT_ADJUST`, `SCREWS_TILT_CALCULATE`
+* V1, Legacy: `BED_TILT`, `SCREWS_TILT_CALCULATE`
+* Trident: `Z_TILT_ADJUST`
 * V2: `QUAD_GANTRY_LEVEL`
 
 ### Bed Screws (V0)


### PR DESCRIPTION
Splitting up Bed Locating (V1, Trident, Legacy) because location of default Z endstop pin location is on different edges.