### PR TITLE
Shiftingtech dfu touchup

### DIFF
--- a/build/software/octopus_klipper.md
+++ b/build/software/octopus_klipper.md
@@ -95,13 +95,14 @@ There are multiple options for getting this firmware file installed onto your Oc
 2. Install the BOOT0 jumper
 3. Connect Octopus & Pi via USB-C
 4. Power on Octopus
-5. From your ssh session, run `lsusb`. and find the ID of the dfu device. The device is typically named `STM Device in DFU mode`.
-6. If you do not see a DFU device in the list, press the reset button next to the USB connector and run `lsusb` again.
-7. Run `make flash FLASH_DEVICE=1234:5678` replace 1234:5678 with the ID from the previous step. Note that the ID is in hexadecimal, it only contains the numbers `0-9` and letters `A-F`.
-8. Power off the Octopus
-9. Remove the jumper from BOOT0 and 3.3V
-10. Power on the Octopus
-11. You can confirm that the flash was successful by running `ls /dev/serial/by-id`.  If the flash was successful, this should now show a klipper device, similar to:
+5. From your ssh session, run `cd ~/klipper` to make sure you are in the correct directory
+6. Run `lsusb`. and find the ID of the dfu device. The device is typically named `STM Device in DFU mode`.
+7. If you do not see a DFU device in the list, press the reset button next to the USB connector and run `lsusb` again.
+8. Run `make flash FLASH_DEVICE=1234:5678` replace 1234:5678 with the ID from the previous step. Note that the ID is in hexadecimal, it only contains the numbers `0-9` and letters `A-F`.
+9. Power off the Octopus
+10. Remove the jumper from BOOT0 and 3.3V
+11. Power on the Octopus
+12. You can confirm that the flash was successful by running `ls /dev/serial/by-id`.  If the flash was successful, this should now show a klipper device, similar to:
  
    ![](./images/stm32f446_id.png)
 

--- a/build/software/spider_klipper.md
+++ b/build/software/spider_klipper.md
@@ -56,12 +56,13 @@ There are multiple options for getting this firmware file installed onto your Sp
 2. Install a jumper between BT0 and 3.3V
 3. Connect Spider & Pi via USB
 4. Power on Spider
-5. From your ssh session, run `lsusb`. and find the ID of the DFU device.
-6. Run `make flash FLASH_DEVICE=1234:5678`, replacing 1234:5678 with the ID from the previous step
-7. Power off the Spider
-8. Remove the jumper from BT0/3.3V
-9. Power up the Spider
-10. You can confirm that the flash was successful by running `ls /dev/serial/by-id`.  If the flash was successful, this should now show a klipper device, similar to:
+5. From your ssh session, run `cd ~/klipper` to make sure you are in the correct directory
+6. Run `lsusb`. and find the ID of the DFU device.
+7. Run `make flash FLASH_DEVICE=1234:5678`, replacing 1234:5678 with the ID from the previous step
+8. Power off the Spider
+9. Remove the jumper from BT0/3.3V
+10. Power up the Spider
+11. You can confirm that the flash was successful by running `ls /dev/serial/by-id`.  If the flash was successful, this should now show a klipper device, similar to:
  
    ![](./images/stm32f446_id.png)
 


### PR DESCRIPTION
We frequently see people turn their pi off, or otherwise loose their ssh session during DFU flashing.  adding an extra
`cd ~/klipper` to the process should avoid some of the resulting confusion