### PR TITLE
Added an updated list of printed parts

### DIFF
--- a/sourcing.md
+++ b/sourcing.md
@@ -34,6 +34,7 @@ Filenames that end with "_x#", indicate that the part must be printed multiple t
 Typical printers require approximately 1.5kg of the primary color and 0.3kg of the alternate color, assuming no failed or reprinted parts. Most people end up reprinting a few parts and a few mods, so plan on 2kg of the primary color.
 
 For informtion on selecting parts to print, clarification of colors and quantities, and even what parts PIF will provide, see the [Printed Part Reference](https://docs.google.com/spreadsheets/d/1njgHapSZLiQHobrEVkeuAuhhDsXzFOJOiIpvfVFeGxQ/edit?usp=sharing) spreadsheet.
+If you are looking for a list of the necessary (and optional) printed parts that you can download and tick off, see the [List of Printed Parts](https://docs.google.com/spreadsheets/d/1xGepU4OfSGdyihcH446__9x0MBUdLXAUNZtiprYMDl4/edit?usp=sharing). (NOTE: this is still a work in progress. For now it only lists the complete build including CW2 and Stealthburner toolhead. Additions following.)
 
 ### Print Settings
 

--- a/sourcing.md
+++ b/sourcing.md
@@ -34,7 +34,7 @@ Filenames that end with "_x#", indicate that the part must be printed multiple t
 Typical printers require approximately 1.5kg of the primary color and 0.3kg of the alternate color, assuming no failed or reprinted parts. Most people end up reprinting a few parts and a few mods, so plan on 2kg of the primary color.
 
 For informtion on selecting parts to print, clarification of colors and quantities, and even what parts PIF will provide, see the [Printed Part Reference](https://docs.google.com/spreadsheets/d/1njgHapSZLiQHobrEVkeuAuhhDsXzFOJOiIpvfVFeGxQ/edit?usp=sharing) spreadsheet.
-If you are looking for a list of the necessary (and optional) printed parts that you can download and tick off, see the [List of Printed Parts](https://docs.google.com/spreadsheets/d/1xGepU4OfSGdyihcH446__9x0MBUdLXAUNZtiprYMDl4/edit?usp=sharing). (NOTE: this is still a work in progress. For now it only lists the complete build including CW2 and Stealthburner toolhead. Additions following.)
+If you are looking for a list of the necessary (and optional) printed parts that you can download and tick off, see the [List of Printed Parts](https://docs.google.com/spreadsheets/d/1xGepU4OfSGdyihcH446__9x0MBUdLXAUNZtiprYMDl4/edit?usp=sharing). (NOTE: this is still a work in progress.)
 
 ### Print Settings
 


### PR DESCRIPTION
The updated list contains references to the parts in the manuals. It includes the CW2 and Stealthburner parts. Also it helps you keep track of your progress by adding tickable boxes.