### PR TITLE
configuration.md: Add missing link to switchwire configuration

### DIFF
--- a/build/software/configuration.md
+++ b/build/software/configuration.md
@@ -14,6 +14,7 @@ Voron Configuration templates are available in the github repository for each pr
 * [V1.8](https://github.com/VoronDesign/Voron-1/tree/Voron1.8/Firmware/klipper_configurations)
 * [Trident](https://github.com/VoronDesign/Voron-Trident/tree/main/Firmware)
 * [V2.4](https://github.com/VoronDesign/Voron-2/tree/Voron2.4/firmware/klipper_configurations)
+* [Switchwire](https://github.com/VoronDesign/Voron-Switchwire/tree/master/Firmware)
 * [Legacy](https://github.com/VoronDesign/Voron-Legacy/tree/main/Firmware)
 
 Note:  When downloading text configuration files from github, click the "raw" button at the top right of the file, and then use your browser's "save-as" function.


### PR DESCRIPTION
Our dear switchwire was missing its firmware configuration after the last commit.

Fix this by linking to the folder including all board firmware configurations for switchwire.