### PR TITLE
Add workflow to merge main into testing/live

### DIFF
--- a/.github/workflows/merge_main.yml
+++ b/.github/workflows/merge_main.yml
@@ -1,0 +1,44 @@
+name: Merge main into testing/live
+run-name: ${{ github.actor }} is merging ${{ github.ref }} into ${{ inputs.targetBranch }} 🚀
+on: 
+  workflow_dispatch:
+    inputs:
+      targetBranch:
+        description: 'Target Branch'
+        required: true
+        default: 'testing'
+        type: choice
+        options:
+        - testing
+        - live
+      force:
+        description: 'Force sync (hard reset to main)'
+        required: true
+        default: false
+        type: boolean
+jobs:
+  manual_merge:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Attempt the merge
+        id: merge_one
+        continue-on-error: true
+        run: |
+          git checkout ${{ inputs.targetBranch }}
+          git merge main --ff-only
+          git push
+      - name: Force merge if necessary
+        if: ${{ job.steps.merge_one.status == failure() && github.event.inputs.force == 'true' }}
+        run: |
+          git checkout ${{ inputs.targetBranch }}
+          git reset --hard main
+          git push --force  
+      - name: Properly fail if force is false
+        if: ${{ job.steps.merge_one.status == failure() && github.event.inputs.force == 'false' }}
+        run: exit 1
+      - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
This adds a workflow to perform the task of merging main to testing/live. To avoid "breaking-by-automation" this workflow is triggered manually from the `Actions` tab by operators of this repo with appropriate permissions.