### PR TITLE
fix typo in hall_effect_endstop_setup.md

### DIFF
--- a/community/electronics/120decibell/hall_effect_endstop_setup.md
+++ b/community/electronics/120decibell/hall_effect_endstop_setup.md
@@ -13,7 +13,7 @@ The hall effect endstop board is a non-mechanical alternative to the X and Y end
 ## Requirements
 
 * The alternate Z joint "z\_joint\_upper\_hall\_effect" must be printed, quantity 1.
-* The alternate endstop pod "[a]\_endstop\_pod\_hall|_effect" must be printed, quantity 1.
+* The alternate endstop pod "[a]\_endstop\_pod\_hall\_effect" must be printed, quantity 1.
 * 4 wires must be installed into the cable chain.
 
 ## Wiring


### PR DESCRIPTION
It was visibly breaking the formatting.

It was visibly breaking the formatting. Published at
https://docs.vorondesign.com/community/electronics/120decibell/hall_effect_endstop_setup.html

---

How it looks before the change:
![image](https://github.com/VoronDesign/Voron-Documentation/assets/993296/f8636a06-5a26-4aa0-9876-88e464a44836)