### PR TITLE
Change G4 in sensorless homing docs to M400

### DIFF
--- a/community/howto/clee/sensorless_xy_homing.md
+++ b/community/howto/clee/sensorless_xy_homing.md
@@ -132,8 +132,9 @@ gcode:
     G91
     G1 X-10 F1200
     
-    # Wait just a second… (give StallGuard registers time to clear)
-    G4 P1000
+    # Wait for current moves to finish (and give StallGuard registers time to clear)
+    M400
+
     # Set current during print
     SET_TMC_CURRENT STEPPER=stepper_x CURRENT={RUN_CURRENT_X}
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
@@ -153,8 +154,9 @@ gcode:
     G91
     G1 Y-10 F1200
 
-    # Wait just a second… (give StallGuard registers time to clear)
-    G4 P1000
+    # Wait for current moves to finish (and give StallGuard registers time to clear)
+    M400
+
     # Set current during print
     SET_TMC_CURRENT STEPPER=stepper_x CURRENT={RUN_CURRENT_X}
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}


### PR DESCRIPTION
M400 is widely used instead of G4 1000 to allow stallguard registers to clear. It is both (usually) faster and more deterministic than dwelling for a set period of time.