### PR TITLE
Add more multimaterial solutions to sourcing guide

### DIFF
--- a/sourcing.md
+++ b/sourcing.md
@@ -97,10 +97,15 @@ Voron does not currently support native, in-house designs for dual extrusion, du
 
 - [BoxTurtle](https://github.com/ArmoredTurtle/BoxTurtle)
 - [Enraged Rabbit Carrot Feeder (ERCF)](https://github.com/Carrot-collective/ERCF_v3)
+- [Tradrack](https://github.com/Annex-Engineering/TradRack)
 - [NightOwl](https://github.com/mjonuschat/NightOwl)
 - [QuattroBox](https://github.com/Batalhoti/QuattroBox)
 - [EMU](https://github.com/DW-Tas/EMU)
+- [3MS](https://github.com/3DCoded/3MS)
+- [KMS](https://github.com/muzixiaoyang/KMS)
+- [3DChameleon](https://github.com/3DChameleon/3DChameleonMk4)
 - [PicoMMU](https://github.com/lhndo/LH-Stinger/wiki/Pico-MMU)
+- [MMX](https://www.printables.com/model/1181017)
 - [MadMax](https://github.com/zruncho3d/madmax)
 - [StealthChanger](https://github.com/DraftShift/StealthChanger)
 


### PR DESCRIPTION
Adds more MMU solutions to the sourcing guide. The additional MMUs are [listed](https://github.com/moggieuk/Happy-Hare#---just-a-few-of-the-features) as supported by Happy Hare MMU software. A couple notes:

- Angry Beaver is omitted since it is not yet released
- BTT ViViD is omitted since it is a commercial system, not a community-provided solution