### PR TITLE
Fix the Jekyll build on Ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,5 @@ gem "github-pages", group: :jekyll_plugins
 #gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 # gem "webrick", "~> 1.8"
+
+gem "csv" # Ruby 3.4 dropped it; Jekyll 3.9 needs it

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    csv (3.3.6)
     dnsruby (1.70.0)
       simpleidn (~> 0.2.1)
     drb (2.2.0)
@@ -227,7 +228,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    nokogiri (1.15.5-x86_64-linux)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -270,6 +271,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  csv
   github-pages
   just-the-docs
 


### PR DESCRIPTION
Deploy previews have been failing on every pull request, including ones that only
touch markdown. The cause is not in this repo's content:

```
jekyll-3.9.3/lib/jekyll.rb:28:in 'Kernel.require':
  cannot load such file -- csv (LoadError)
```

Netlify's build image moved to Ruby 3.4, which dropped `csv` from the default gems.
Jekyll 3.9.3 requires `csv` without declaring it as a dependency, so the build dies
before Jekyll starts. Declaring it in the Gemfile is enough.

Verified in a `ruby:3.4.10` container against a clean bundle: 117 pages build in
about five seconds, with no gems compiled from source.

`nokogiri` moves in the lockfile because the precompiled 1.15.5 gem has no build for
Ruby 3.4. Pinning it would make every deploy compile nokogiri from source instead, so
the lockfile takes the newer precompiled gem.

This does not change the published site. GitHub Pages serves the `live` branch with
its own Jekyll 3.9 and ignores this Gemfile, which is why production kept building
while previews broke.

I also tried moving to Ruby 4 rather than patching around 3.4, and it is not viable
today: after adding `csv`, `logger`, `bigdecimal` and `base64`, the build still fails
on `liquid-4.0.3` calling `String#tainted?`, which the language removed. Getting there
means upgrading Liquid, which means Jekyll 4, which means dropping the `github-pages`
gem, and then previews would build a different Jekyll than the one that actually
serves the site.